### PR TITLE
callThrough on matchMedia stub so only one behavior is stubbed

### DIFF
--- a/test/e2e/specs/common/index.ts
+++ b/test/e2e/specs/common/index.ts
@@ -4,6 +4,7 @@ Given('I open the home page', () => {
   cy.visit(Cypress.env('BASE_URL'), {
     onBeforeLoad(win) {
       cy.stub(win, 'matchMedia')
+        .callThrough()
         .withArgs('(prefers-color-scheme: dark)')
         .returns({
           matches: false,


### PR DESCRIPTION
saw an issue where other matchMedia calls would not return a value since the stub did not provide one; this allows for default behavior except in the supplied color scheme case 